### PR TITLE
Adding Support for non-environment configuration

### DIFF
--- a/Utilites/Tokenizer/tokenize.ps1
+++ b/Utilites/Tokenizer/tokenize.ps1
@@ -11,90 +11,118 @@ param
 
 . $PSScriptRoot\Helpers.ps1
 
-#ConfigurationJsonFile has multiple environment sections.
-$environmentName="default"
-if (Test-Path -Path env:RELEASE_ENVIRONMENTNAME){
-	$environmentName=(get-item env:RELEASE_ENVIRONMENTNAME).value
-}
-Write-Host "Environment:"$environmentName
-# Validate that $SourcePath is a valid path
-if (!(Test-Path -Path $SourcePath)){
-    throw "$SourcePath is not a valid path. Please provide a valid path"
-}
-
-# Set $DestinationPath as $SourcePath if it is not passed as input. So, SourceFile gets transformed as DestinationFile
-if($DestinationPath -eq ''){
-    $DestinationPath = $SourcePath
-}
-
-# Is SourceFile an XML document
-$SourceIsXml=Test-ValidXmlFile $SourcePath
-# Is there a valid Configuration Json input provided for modifying configuration
-if($ConfigurationJsonFile -ne ''){
-    $Configuration=Get-JsonFromFile $ConfigurationJsonFile
-} 
-
-<#
-    Step 1:- if the SourceIsXml and a valid configuration file is provided then 
-        Run through all the XPaths in the Json Configuration and update the XML file
-#>
-
-if(($SourceIsXml) -and ($Configuration)){
-    $keys= $Configuration.$environmentName.ConfigChanges
+function UpdateConfig ($SourcePath, $jsonContent, $envName, $DestinationPath )
+{
+    if( $envName )
+    {
+        $keys= $jsonContent.$envName.ConfigChanges
+    }
+    else
+    {
+        $keys= $jsonContent.ConfigChanges
+    }
 
     $xmlraw=[xml](Get-Content $SourcePath)
     ForEach($key in $keys){
+        "Looking for key: $($key.KeyName)"
         $node=$xmlraw.SelectSingleNode($key.KeyName)
         if($node) {
+            "Key found: $($key.KeyName)"
             try{
-                Write-Host "Updating " $key.Attribute "of " $key.KeyName ":" $key.Value 
+                "Updating $($key.Attribute) of $($key.KeyName): $($key.Value)" 
                 $node.($key.Attribute)=$key.Value
-                }
+            }
             catch{
             }
         }
     }
     $xmlraw.Save($DestinationPath)
-
-
 }
-<#
-  Step 2:- For each token in the source configuration that matches with the regular expression __<tokenname>__
-            i.	If there is a custom variable at build or release definition then replace the token with the value of the same..
-            ii.	If the variable is available in the configuration section of json document then replace the token with the vaule from json document
-            iii.Or else it ignores the token
-#>
-$regex = '__[A-Za-z0-9._-]*__'
-$matches = @()
-$tempFile = $DestinationPath + '.tmp'
-Copy-Item -Force $DestinationPath $tempFile
 
-$matches = select-string -Path $tempFile -Pattern $regex -AllMatches | % { $_.Matches } | % { $_.Value }
-ForEach($match in $matches)
+function Tokenize($SourcePath, $DestinationPath, $ConfigurationJsonFile)
 {
-  $matchedItem = $match
-  $matchedItem = $matchedItem.Trim('_')
-  $matchedItem = $matchedItem -replace '\.','_'
-  (Get-Content $tempFile) | 
-  Foreach-Object {
-    $variableValue=$match
-    try{
-        if(Test-Path env:$matchedItem){
-            $variableValue=(get-item env:$matchedItem).Value
-            }
-        else{
-            if($Configuration.$environmentName.CustomVariables.$matchedItem){
-                $variableValue=$Configuration.$environmentName.CustomVariables.$matchedItem
-            }
-        }
-        }
-    catch{
-        $variableValue=$match
+    #ConfigurationJsonFile has multiple environment sections.
+    $environmentName="default"
+    if (Test-Path -Path env:RELEASE_ENVIRONMENTNAME){
+	    $environmentName=(get-item env:RELEASE_ENVIRONMENTNAME).value
     }
-    $_ -replace $match,$variableValue
-  } | 
-Set-Content $tempFile -Force
+    "Environment: $environmentName"
+    # Validate that $SourcePath is a valid path
+    if (!(Test-Path -Path $SourcePath)){
+        throw "$SourcePath is not a valid path. Please provide a valid path"
+    }
+
+    # Set $DestinationPath as $SourcePath if it is not passed as input. So, SourceFile gets transformed as DestinationFile
+    if($DestinationPath -eq ''){
+        $DestinationPath = $SourcePath
+    }
+
+    # Is SourceFile an XML document
+    $SourceIsXml=Test-ValidXmlFile $SourcePath
+
+    # Is there a valid Configuration Json input provided for modifying configuration
+    if($ConfigurationJsonFile -ne ''){
+        $Configuration=Get-JsonFromFile $ConfigurationJsonFile
+    } 
+
+    <#
+        Step 1:- if the SourceIsXml and a valid configuration file is provided then 
+            Run through all the XPaths in the Json Configuration and update the XML file
+    #>
+
+    if(($SourceIsXml) -and ($Configuration)){
+	    "Updating Config using Json config file..."
+        #Do non-env specific update first
+        UpdateConfig -SourcePath $SourcePath -jsonContent $Configuration -DestinationPath $DestinationPath
+
+        #do Env specific update, this will trump any non-env specific changes
+        UpdateConfig -SourcePath $SourcePath -jsonContent $Configuration -envName $environmentName -DestinationPath $DestinationPath
+
+    }
+
+    <#
+      Step 2:- For each token in the source configuration that matches with the regular expression __<tokenname>__
+                i.	If there is a custom variable at build or release definition then replace the token with the value of the same..
+                ii.	If the variable is available in the configuration section of json document then replace the token with the vaule from json document
+                iii.Or else it ignores the token
+    #>
+    $regex = '__[A-Za-z0-9._-]*__'
+    $matches = @()
+    $tempFile = $DestinationPath + '.tmp'
+    Copy-Item -Force $DestinationPath $tempFile
+
+    "Replacing tokens..."
+    $matches = select-string -Path $tempFile -Pattern $regex -AllMatches | % { $_.Matches } | % { $_.Value }
+    ForEach($match in $matches)
+    {
+      $matchedItem = $match
+      $matchedItem = $matchedItem.Trim('_')
+      $matchedItem = $matchedItem -replace '\.','_'
+      (Get-Content $tempFile) | 
+      Foreach-Object {
+        $variableValue=$match
+        try{
+            if(Test-Path env:$matchedItem){
+                $variableValue=(get-item env:$matchedItem).Value
+                }
+            else{
+                if($Configuration.$environmentName.CustomVariables.$matchedItem){
+                    $variableValue=$Configuration.$environmentName.CustomVariables.$matchedItem
+                }
+            }
+            }
+        catch{
+            $variableValue=$match
+        }
+        $_ -replace $match,$variableValue
+      } | 
+    Set-Content $tempFile -Force
+    }
+
+    Copy-Item -Force $tempFile $DestinationPath
+    Remove-Item -Force $tempFile
+    "Done"
 }
 
-Copy-Item -Force $tempFile $DestinationPath
-Remove-Item -Force $tempFile
+# Piped output to Out-String first to remove new lines, then pipe that to Write-Verbose to get messages to show up in log.  Write-Host won't show up.
+Tokenize -SourcePath $SourcePath -DestinationPath $DestinationPath -ConfigurationJsonFile $ConfigurationJsonFile | Out-String | Write-Verbose -Verbose

--- a/Utilites/overview.md
+++ b/Utilites/overview.md
@@ -14,37 +14,41 @@ This task finds the pattern:  **\_\_\<pattern\>\_\_** and replaces the same with
 #### (Optional) Tokenization based on XML / XPath
 If **Configuration Json filename** is provided (optional):
 A configuration Json document is provided as an input that contains a section ConfigChanges to provide KeyName the XPath to identify a particular node in the XML document, Attribute name that needs to be set and Value to be set. And this configuration can be maintained for multiple environments.
-Below is the sample for the Json document that can be provided as input. There can be multiple sections for each <environment>
+Below is the sample for the Json document that can be provided as input. There can be multiple sections for each <environment>.  There can also be a non-environment related set of Config changes.  Its recommended to put tokens here for values, then they will be replaced by the tokenize step with 
+variable values.
 ```
 {
-  "<environment>": {
-    "CustomVariables": {
-    "Variable1": "value1",
-    "Variable2": "value2",
-  },
-    "ConfigChanges": [
+	"<environment>": {
+		"CustomVariables": {
+		"Variable1": "value1",
+		"Variable2": "value2",
+		},
+		"ConfigChanges": [
+			{
+			  "KeyName": "/configuration/appSettings/add[@key='EnableDebugging']",
+			  "Attribute":"value",
+			  "Value":"false"
+			},
+			{
+			  "KeyName":“/configuration/connectionStrings/add[@name='databaseentities']”,
+			  "Attribute": "connectionString",
+			  "value": "Integrated Security=True;Persist Security Info=False;Initial Catalog=DB;Data Source=servername"
+			}
+		]
+	},
+	"ConfigChanges": [
         {
           "KeyName": "/configuration/appSettings/add[@key='ServiceURL']",
           "Attribute":"value",
-          "Value":"https://ServiceURL"
-        },
-        {
-          "KeyName": "/configuration/appSettings/add[@key='EnableDebugging']",
-          "Attribute":"value",
-          "Value":"false"
-        },
-        {
-          "KeyName":“/configuration/connectionStrings/add[@name='databaseentities']”,
-          "Attribute": "connectionString",
-          "value": "Integrated Security=True;Persist Security Info=False;Initial Catalog=DB;Data Source=servername"
+          "Value":"__ServiceUrl__"
         }
-    ]
+	]
 }
 ```
 Below is the list of inputs for the task: 
 **Source filename*** - Source file name that contains the tokens (\_\_<variable-name>\_\_). These patterns will be replaced with user-defined variables or from Configuration Json FileName. If it is an XML document, XPaths mentioned in the Configuration JsonFileName will be set as per environment. 
 **Destination filename** (optional) - Destination filename that has transformed Source filename. If this is empty, the 'Source filename' will be modified. 
-**Configuration Json filename** (optional) - Json file that contains environment specific settings in the form XPath, Attribute, Value and values for user-defined variables. 
+**Configuration Json filename** (optional) - Json file that contains environment and non-environment specific settings in the form XPath, Attribute, Value and values for user-defined variables. 
 Refer above for the schema/format of the Json filename. If this parameter is not specified, then custom variables mentioned against the build/release are used to replace the tokens that match the regular expression \_\_<variable-name>\_\_
 
 


### PR DESCRIPTION
Updated to support non-environment configurations.  This allows for a
config file to replace settings with variable tokens, then those tokens
to get replaced with TFS values.  This allows for config files to
contain actual values instead of doing a transform during a build to
inject tokens into the config.  And the token injection points would be
the same for all environments.
