### PR TITLE
Tokenizer does not handle encrypted environment variables

### DIFF
--- a/Utilites/Tokenizer/task.json
+++ b/Utilites/Tokenizer/task.json
@@ -11,7 +11,7 @@
   "author": "ms-devlabs",
   "version": {
     "Major": 1,
-    "Minor": 1,
+    "Minor": 2,
     "Patch": 0
   },
   "demands": [

--- a/Utilites/Tokenizer/tokenize.ps1
+++ b/Utilites/Tokenizer/tokenize.ps1
@@ -16,7 +16,6 @@ Write-Verbose "ConfigurationJsonFile = $ConfigurationJsonFile"
 
 . $PSScriptRoot\Helpers.ps1
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.Internal" 
-import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common" 
 
 #ConfigurationJsonFile has multiple environment sections.
 $environmentName="default"
@@ -90,9 +89,7 @@ ForEach($match in $matches)
   $matchedItem = $matchedItem.Trim('_')
   $matchedItem = $matchedItem -replace '\.','_'
   
-  Write-Host (Get-LocalizedString -Key 'Token {0}...' -ArgumentList $matchedItem) -ForegroundColor Green
-        
-	$variableValue=$match
+   $variableValue=$match
     try{
         if(Test-Path env:$matchedItem){
 			 $matchedItem = $matchedItem -replace '_','.'
@@ -106,10 +103,7 @@ ForEach($match in $matches)
         }
     catch{
         $variableValue=$match
-    }
-
-	Write-Host (Get-LocalizedString -Key 'Token Value: {0}...' -ArgumentList $variableValue) -ForegroundColor Green
-  
+    }  
   
   (Get-Content $tempFile) | 
   Foreach-Object {    


### PR DESCRIPTION
I've fixed problem with encrypted environment variables.