### PR TITLE
Rollback task always select result from first "Deploy" task and ignor…

### DIFF
--- a/Utilites/Rollback/Runpowershellwithtaskcontext.ps1
+++ b/Utilites/Rollback/Runpowershellwithtaskcontext.ps1
@@ -15,7 +15,7 @@ Write-Verbose -Verbose "inlineScripe = $script"
 import-module "Microsoft.TeamFoundation.DistributedTask.Task.Common"
 
 # Construct the REST URL to obtain Build ID
-$releasequeryuri = "$($env:SYSTEM_TEAMFOUNDATIONSERVERURI)$($env:SYSTEM_TEAMPROJECT)/_apis/release/releases/$($env:Release_ReleaseId)/environments/$($env:RELEASE_ENVIRONMENTURI.Split('/')[-1])/tasks?api-version=2.1-preview.1"
+$releasequeryuri = "$($env:SYSTEM_TEAMFOUNDATIONSERVERURI)$($env:SYSTEM_TEAMPROJECT)/_apis/release/releases/$($env:Release_ReleaseId)/environments/$($env:RELEASE_ENVIRONMENTURI.Split('/')[-1])?api-version=2.1-preview.1"
 $taskexecutioninfo = @{}
 $releasequeryresult = $null
 $personalAccessToken = $null
@@ -63,7 +63,9 @@ if (!$releasequeryresult -or $releasequeryresult.count -eq 0)
 }
 else
 {    
-    $jobtasks = $releasequeryresult.value | Sort-Object dateStarted
+    $tasks = $releasequeryresult.deploySteps | Sort-Object attempt -Descending | select -First 1
+    $jobtasks = $tasks.tasks | Sort-Object dateStarted
+
     $ignoreResultentry = $true
 
     Write-Verbose -Verbose  "Obtained $($jobtasks.Count) tasks from task history"


### PR DESCRIPTION
…e new "Redeploy" task result

Changed REST API Uri and filtered task by numbers (highest one in the
release) to get result from latest task for Rollback (in case of
Redeploy)