### PR TITLE
Add XML namespace configuration for Tokenizer

### DIFF
--- a/Utilites/Tokenizer/tokenize-ps3.ps1
+++ b/Utilites/Tokenizer/tokenize-ps3.ps1
@@ -61,7 +61,15 @@ try {
 
         $xmlraw = [xml](Get-Content $SourcePath)
         ForEach ($key in $keys) {
-            $node = $xmlraw.SelectSingleNode($key.KeyName)
+            # Check for a namespaced element
+            if ($key.NamespaceUrl -And $key.NamespacePrefix) {
+                $ns = New-Object System.Xml.XmlNamespaceManager($xmlraw.NameTable)
+                $ns.AddNamespace($key.NamespacePrefix, $key.NamespaceUrl)
+                $node = $xmlraw.SelectSingleNode($key.KeyName, $ns)
+            } else {
+                $node = $xmlraw.SelectSingleNode($key.KeyName)
+            }
+
             if ($node) {
                 try {
                     Write-Host "Updating $($key.Attribute) of $($key.KeyName): $($key.Value)"
@@ -70,6 +78,8 @@ try {
                 catch {
                     Write-Error "Failure while updating $($key.Attribute) of $($key.KeyName): $($key.Value)"
                 }
+            } else {
+               Write-Verbose "'$($key.KeyName)' not found in source"
             }
         }
         $xmlraw.Save($tempFile)

--- a/Utilites/Tokenizer/tokenize.ps1
+++ b/Utilites/Tokenizer/tokenize.ps1
@@ -58,7 +58,15 @@ if (($SourceIsXml) -and ($Configuration)) {
 
     $xmlraw = [xml](Get-Content $SourcePath)
     ForEach ($key in $keys) {
-        $node = $xmlraw.SelectSingleNode($key.KeyName)
+        # Check for a namespaced element
+        if ($key.NamespaceUrl -And $key.NamespacePrefix) {
+            $ns = New-Object System.Xml.XmlNamespaceManager($xmlraw.NameTable)
+            $ns.AddNamespace($key.NamespacePrefix, $key.NamespaceUrl)
+            $node = $xmlraw.SelectSingleNode($key.KeyName, $ns)
+        } else {
+            $node = $xmlraw.SelectSingleNode($key.KeyName)
+        }
+
         if ($node) {
             try {
                 Write-Host "Updating $($key.Attribute) of $($key.KeyName): $($key.Value)"

--- a/Utilites/overview.md
+++ b/Utilites/overview.md
@@ -51,6 +51,19 @@ If the **Source filename** uses xml namespaces in some nodes, use a generic XPat
           "KeyName": "/*[local-name()='configuration']/*[local-name()='connectionStrings']/*[local-name()='add'][@name='serviceUrl']"
           ...
 ```
+Or specify the namespace URL and prefix in the config, e.g.
+
+```
+...
+"ConfigChanges": [
+    {
+        "KeyName": "/configuration/ns:nlog/ns:targets/ns:target[@name='email']",
+        "Attribute": "to",
+        "value": "logs@test.com",
+        "NamespaceUrl": "http://www.nlog-project.org/schemas/NLog.xsd",
+        "NamespacePrefix": "ns"
+    }
+```
 
 #### Parameters
 Below is the list of inputs for the task: 


### PR DESCRIPTION
Adds two additional configuration variables `NamespaceUrl` and `NamespacePrefix` to specify when a namespace is used in the targeted XML KeyName.

Resolves #46